### PR TITLE
Add RBAC and multi-tenancy foundations

### DIFF
--- a/src/backend/core/migrations/20240101000004_rbac_tables.sql
+++ b/src/backend/core/migrations/20240101000004_rbac_tables.sql
@@ -1,0 +1,255 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Project Apex - RBAC & Multi-Tenancy Schema
+-- Migration: 20240101000004_rbac_tables.sql
+-- Description: Creates tables for role-based access control and tenant isolation
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- CUSTOM TYPES
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TYPE organization_status AS ENUM ('active', 'suspended', 'deactivated');
+CREATE TYPE member_role AS ENUM ('owner', 'admin', 'member');
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- ORGANIZATIONS (tenants)
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE organizations (
+    id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name        TEXT        NOT NULL,
+    slug        TEXT        NOT NULL UNIQUE,
+    status      organization_status NOT NULL DEFAULT 'active',
+    owner_id    UUID        NOT NULL,           -- references users.id once created
+    settings    JSONB       NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE organizations IS 'Tenant organizations; every resource is scoped to an organization';
+
+CREATE INDEX idx_organizations_slug   ON organizations (slug);
+CREATE INDEX idx_organizations_owner  ON organizations (owner_id);
+CREATE INDEX idx_organizations_status ON organizations (status);
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- USERS
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE users (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email           TEXT        NOT NULL UNIQUE,
+    name            TEXT,
+    password_hash   TEXT,                       -- NULL for SSO-only users
+    is_active       BOOLEAN     NOT NULL DEFAULT TRUE,
+    last_login_at   TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE users IS 'Application users who interact with Apex';
+
+CREATE INDEX idx_users_email     ON users (email);
+CREATE INDEX idx_users_is_active ON users (is_active);
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- ORGANIZATION MEMBERS
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE organization_members (
+    user_id         UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    organization_id UUID        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    role            member_role NOT NULL DEFAULT 'member',
+    joined_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (user_id, organization_id)
+);
+
+COMMENT ON TABLE organization_members IS 'Maps users to organizations with a membership role';
+
+CREATE INDEX idx_org_members_org  ON organization_members (organization_id);
+CREATE INDEX idx_org_members_user ON organization_members (user_id);
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- ROLES
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE roles (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name            TEXT        NOT NULL,
+    description     TEXT        NOT NULL DEFAULT '',
+    is_system       BOOLEAN     NOT NULL DEFAULT FALSE,
+    organization_id UUID        REFERENCES organizations(id) ON DELETE CASCADE,  -- NULL = global role
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- A role name must be unique within its scope (global or per-org).
+    UNIQUE (name, organization_id)
+);
+
+COMMENT ON TABLE roles IS 'RBAC roles that group permissions; system roles cannot be deleted';
+
+CREATE INDEX idx_roles_org       ON roles (organization_id);
+CREATE INDEX idx_roles_is_system ON roles (is_system);
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- PERMISSIONS
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE permissions (
+    id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    resource    TEXT NOT NULL,                  -- e.g., 'swarm', 'agent', 'task'
+    action      TEXT NOT NULL,                  -- e.g., 'create', 'read', 'delete', 'manage'
+    description TEXT NOT NULL DEFAULT '',
+
+    UNIQUE (resource, action)
+);
+
+COMMENT ON TABLE permissions IS 'Individual permissions representing resource:action pairs';
+
+-- Seed the defined permissions
+INSERT INTO permissions (resource, action, description) VALUES
+    ('swarm',    'create',  'Create new agent swarms'),
+    ('swarm',    'read',    'View swarm details and status'),
+    ('swarm',    'delete',  'Delete existing swarms'),
+    ('agent',    'manage',  'Manage agents (create, update, remove)'),
+    ('agent',    'read',    'View agent details and status'),
+    ('task',     'submit',  'Submit new tasks to the system'),
+    ('task',     'read',    'View task details and results'),
+    ('approval', 'approve', 'Approve pending human-in-the-loop actions'),
+    ('approval', 'read',    'View pending approval requests'),
+    ('settings', 'manage',  'Manage organization and system settings'),
+    ('settings', 'read',    'View organization and system settings');
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- ROLE-PERMISSION MAPPING
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE role_permissions (
+    role_id       UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id UUID NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+
+    PRIMARY KEY (role_id, permission_id)
+);
+
+COMMENT ON TABLE role_permissions IS 'Maps roles to their granted permissions';
+
+CREATE INDEX idx_role_perms_role ON role_permissions (role_id);
+CREATE INDEX idx_role_perms_perm ON role_permissions (permission_id);
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- USER-ROLE BINDINGS (per organization)
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE user_roles (
+    user_id         UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role_id         UUID        NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    organization_id UUID        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    granted_by      UUID        REFERENCES users(id) ON DELETE SET NULL,
+    expires_at      TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (user_id, role_id, organization_id)
+);
+
+COMMENT ON TABLE user_roles IS 'Binds users to roles scoped to a specific organization';
+
+CREATE INDEX idx_user_roles_user ON user_roles (user_id);
+CREATE INDEX idx_user_roles_role ON user_roles (role_id);
+CREATE INDEX idx_user_roles_org  ON user_roles (organization_id);
+CREATE INDEX idx_user_roles_exp  ON user_roles (expires_at) WHERE expires_at IS NOT NULL;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- SEED SYSTEM ROLES
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- Insert the four predefined system roles (global scope, organization_id = NULL).
+INSERT INTO roles (name, description, is_system) VALUES
+    ('admin',     'Full access to all resources and organization settings', TRUE),
+    ('operator',  'Manage swarms, agents, and tasks; approve actions',      TRUE),
+    ('developer', 'Create and manage swarms and tasks',                     TRUE),
+    ('viewer',    'Read-only access to all resources',                      TRUE);
+
+-- Wire up admin: wildcard (all permissions)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'admin' AND r.is_system = TRUE;
+
+-- Wire up operator permissions
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON (p.resource, p.action) IN (
+    ('swarm', 'create'), ('swarm', 'read'), ('swarm', 'delete'),
+    ('agent', 'manage'),
+    ('task', 'submit'), ('task', 'read'),
+    ('approval', 'approve')
+)
+WHERE r.name = 'operator' AND r.is_system = TRUE;
+
+-- Wire up developer permissions
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON (p.resource, p.action) IN (
+    ('swarm', 'create'), ('swarm', 'read'),
+    ('agent', 'manage'),
+    ('task', 'submit'), ('task', 'read')
+)
+WHERE r.name = 'developer' AND r.is_system = TRUE;
+
+-- Wire up viewer permissions (read-only)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON (p.resource, p.action) IN (
+    ('swarm', 'read'),
+    ('agent', 'read'),
+    ('task', 'read'),
+    ('approval', 'read'),
+    ('settings', 'read')
+)
+WHERE r.name = 'viewer' AND r.is_system = TRUE;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- UPDATED_AT TRIGGER
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- Reuse the existing trigger function if available, otherwise create it.
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_organizations_updated_at
+    BEFORE UPDATE ON organizations
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER trg_users_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER trg_roles_updated_at
+    BEFORE UPDATE ON roles
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- ROW-LEVEL SECURITY (tenant isolation foundation)
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+-- Enable RLS on organization-scoped tables.
+-- Policies will be activated when the application sets `current_setting('app.current_org_id')`.
+
+ALTER TABLE organizations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY org_isolation_policy ON organizations
+    USING (id::text = current_setting('app.current_org_id', TRUE));
+
+-- Note: Additional RLS policies for other tenant-scoped tables (swarms, tasks, etc.)
+-- should reference organization_id = current_setting('app.current_org_id', TRUE)
+-- and will be added as those tables gain the organization_id column.

--- a/src/backend/core/src/lib.rs
+++ b/src/backend/core/src/lib.rs
@@ -15,6 +15,7 @@
 //! - **Validation**: Comprehensive request validation with sync and async support
 //! - **Cache**: Multi-tier caching with tag-based invalidation and HTTP caching middleware
 //! - **Pagination**: Cursor and offset-based pagination utilities
+//! - **RBAC**: Role-based access control with multi-tenancy and policy engine
 
 pub mod orchestrator;
 pub mod dag;
@@ -29,6 +30,7 @@ pub mod config;
 pub mod error;
 pub mod websocket;
 pub mod middleware;
+pub mod rbac;
 pub mod validation;
 pub mod cache;
 pub mod pagination;
@@ -53,6 +55,13 @@ pub mod prelude {
         TaskUpdate, AgentUpdate, DagUpdate, MetricsSnapshot,
         ApprovalRequest, ApprovalResponse,
         RoomId, RoomType,
+    };
+    pub use crate::rbac::{
+        PolicyEngine, PolicyDecision, PolicyError,
+        Permission, Role, RoleId, RoleBinding, UserId, OrganizationId,
+        Organization, OrganizationMember, OrganizationStatus, MemberRole,
+        ResourceScope, PredefinedRole,
+        RequirePermissionLayer, RequirePermissionService, RbacContext,
     };
     pub use crate::middleware::{
         RateLimitLayer, RateLimitConfig, RateLimitError,

--- a/src/backend/core/src/rbac/middleware.rs
+++ b/src/backend/core/src/rbac/middleware.rs
@@ -1,0 +1,277 @@
+//! Axum authorization middleware that enforces RBAC permissions on requests.
+//!
+//! This middleware reads the `AuthContext` (injected by the auth middleware)
+//! and checks the policy engine to decide whether the request should proceed.
+
+use axum::{
+    body::Body,
+    extract::{FromRequestParts, Request},
+    http::{request::Parts, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+use tracing::warn;
+
+use super::models::{OrganizationId, Permission, UserId};
+use super::policy::PolicyEngine;
+use crate::middleware::auth::AuthContext;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RBAC Context (extracted in handlers)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Extended authorization context that includes RBAC-resolved information.
+///
+/// Inserted into request extensions by the authorization middleware so that
+/// downstream handlers can access the verified user, organization, and
+/// effective permissions without re-evaluating the policy.
+#[derive(Debug, Clone)]
+pub struct RbacContext {
+    /// The authenticated user id.
+    pub user_id: UserId,
+    /// The organization scope for this request.
+    pub organization_id: OrganizationId,
+    /// The permission that was checked (if middleware was applied).
+    pub checked_permission: Option<Permission>,
+}
+
+/// Axum extractor for `RbacContext`.
+#[axum::async_trait]
+impl<S> FromRequestParts<S> for RbacContext
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<RbacContext>()
+            .cloned()
+            .ok_or_else(|| {
+                let body = serde_json::json!({
+                    "success": false,
+                    "error": {
+                        "code": "MISSING_RBAC_CONTEXT",
+                        "message": "Authorization context not available. Ensure RBAC middleware is applied.",
+                    }
+                });
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+            })
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Tower Layer
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Layer that wraps services with permission enforcement.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use apex_core::rbac::{RequirePermissionLayer, PolicyEngine};
+///
+/// let engine = PolicyEngine::new();
+/// // ... load roles and bindings ...
+///
+/// let app = Router::new()
+///     .route("/api/v1/swarms", post(create_swarm))
+///     .layer(RequirePermissionLayer::new(engine.clone(), "swarm:create"));
+/// ```
+#[derive(Clone)]
+pub struct RequirePermissionLayer {
+    engine: Arc<PolicyEngine>,
+    permission: Permission,
+}
+
+impl RequirePermissionLayer {
+    /// Create a new layer requiring the given permission (e.g., `"swarm:create"`).
+    pub fn new(engine: Arc<PolicyEngine>, permission_str: &str) -> Self {
+        let permission = Permission::parse(permission_str)
+            .unwrap_or_else(|| Permission::new(permission_str, "*"));
+        Self { engine, permission }
+    }
+
+    /// Create from an already-parsed `Permission`.
+    pub fn from_permission(engine: Arc<PolicyEngine>, permission: Permission) -> Self {
+        Self { engine, permission }
+    }
+}
+
+impl<S> Layer<S> for RequirePermissionLayer {
+    type Service = RequirePermissionService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequirePermissionService {
+            inner,
+            engine: self.engine.clone(),
+            permission: self.permission.clone(),
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Tower Service
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Service that enforces a required permission per request.
+#[derive(Clone)]
+pub struct RequirePermissionService<S> {
+    inner: S,
+    engine: Arc<PolicyEngine>,
+    permission: Permission,
+}
+
+impl<S> Service<Request<Body>> for RequirePermissionService<S>
+where
+    S: Service<Request<Body>, Response = Response> + Clone + Send + 'static,
+    S::Future: Send,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: Request<Body>) -> Self::Future {
+        let engine = self.engine.clone();
+        let permission = self.permission.clone();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            // Extract auth context set by upstream auth middleware.
+            let auth_ctx = request
+                .extensions()
+                .get::<AuthContext>()
+                .cloned();
+
+            let auth_ctx = match auth_ctx {
+                Some(ctx) if ctx.is_authenticated() => ctx,
+                _ => {
+                    return Ok(forbidden_response(
+                        "Authentication required for this resource",
+                    ));
+                }
+            };
+
+            // Determine organization from auth context.
+            let org_id = match &auth_ctx.org_id {
+                Some(id) => OrganizationId::new(id),
+                None => {
+                    return Ok(forbidden_response(
+                        "Organization context required. Include org_id in your token.",
+                    ));
+                }
+            };
+
+            let user_id = UserId::new(&auth_ctx.user_id);
+
+            // Evaluate policy.
+            let decision = engine.check(&user_id, &permission, &org_id);
+
+            if decision.is_denied() {
+                warn!(
+                    user_id = %user_id,
+                    permission = %permission,
+                    org_id = %org_id,
+                    "Permission denied"
+                );
+                return Ok(forbidden_response(&format!(
+                    "You do not have permission: {}",
+                    permission
+                )));
+            }
+
+            // Inject RBAC context for downstream handlers.
+            let rbac_ctx = RbacContext {
+                user_id,
+                organization_id: org_id,
+                checked_permission: Some(permission),
+            };
+            request.extensions_mut().insert(rbac_ctx);
+
+            inner.call(request).await
+        })
+    }
+}
+
+/// Build a 403 Forbidden JSON response.
+fn forbidden_response(message: &str) -> Response {
+    let body = serde_json::json!({
+        "success": false,
+        "error": {
+            "code": "FORBIDDEN",
+            "message": message,
+        }
+    });
+    (StatusCode::FORBIDDEN, Json(body)).into_response()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::auth::{AuthContext, AuthMethod};
+    use crate::rbac::models::RoleBinding;
+    use crate::rbac::roles::PredefinedRole;
+
+    fn setup_engine_with_user(
+        uid: &str,
+        role: &str,
+        oid: &str,
+    ) -> Arc<PolicyEngine> {
+        let engine = PolicyEngine::new();
+        engine.load_roles(PredefinedRole::all_defaults());
+        engine.bind_role(RoleBinding::new(
+            UserId::new(uid),
+            super::super::models::RoleId::new(role),
+            OrganizationId::new(oid),
+        ));
+        Arc::new(engine)
+    }
+
+    fn make_auth_context(user_id: &str, org_id: Option<&str>) -> AuthContext {
+        AuthContext {
+            user_id: user_id.to_string(),
+            email: None,
+            name: None,
+            roles: vec![],
+            org_id: org_id.map(|s| s.to_string()),
+            auth_method: AuthMethod::Jwt,
+            token_id: None,
+            expires_at: None,
+            request_id: "test-req".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_rbac_context_creation() {
+        let ctx = RbacContext {
+            user_id: UserId::new("alice"),
+            organization_id: OrganizationId::new("org1"),
+            checked_permission: Some(Permission::new("swarm", "create")),
+        };
+
+        assert_eq!(ctx.user_id.as_str(), "alice");
+        assert_eq!(ctx.organization_id.as_str(), "org1");
+    }
+
+    #[test]
+    fn test_require_permission_layer_parse() {
+        let engine = Arc::new(PolicyEngine::new());
+        let layer = RequirePermissionLayer::new(engine, "swarm:create");
+        assert_eq!(layer.permission.resource, "swarm");
+        assert_eq!(layer.permission.action, "create");
+    }
+}

--- a/src/backend/core/src/rbac/mod.rs
+++ b/src/backend/core/src/rbac/mod.rs
@@ -1,0 +1,48 @@
+//! Role-Based Access Control (RBAC) and multi-tenancy foundations.
+//!
+//! This module provides:
+//! - **Models**: Role, Permission, User, Organization data structures
+//! - **Policy Engine**: Evaluates whether a user can perform an action on a resource
+//! - **Predefined Roles**: Admin, Operator, Viewer, Developer with default permission sets
+//! - **Authorization Middleware**: Axum middleware for request-level permission checks
+//! - **Tenant Isolation**: Organization-scoped resource access
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use apex_core::rbac::{
+//!     PolicyEngine, Permission, RequirePermission,
+//!     roles::PredefinedRole,
+//! };
+//!
+//! // Check permissions programmatically
+//! let engine = PolicyEngine::new();
+//! engine.load_role_permissions(PredefinedRole::all_defaults());
+//!
+//! let allowed = engine.check(
+//!     &user_id,
+//!     &Permission::new("swarm", "create"),
+//!     Some(&org_id),
+//! );
+//!
+//! // Use as Axum middleware
+//! let app = Router::new()
+//!     .route("/api/v1/swarms", post(create_swarm))
+//!     .layer(RequirePermissionLayer::new(engine, "swarm:create"));
+//! ```
+
+pub mod models;
+pub mod policy;
+pub mod middleware;
+pub mod roles;
+
+pub use models::{
+    Permission, Role, RoleId, RoleBinding, UserId, OrganizationId,
+    Organization, OrganizationMember, OrganizationStatus, MemberRole,
+    ResourceScope,
+};
+pub use policy::{PolicyEngine, PolicyDecision, PolicyError};
+pub use middleware::{
+    RequirePermissionLayer, RequirePermissionService, RbacContext,
+};
+pub use roles::PredefinedRole;

--- a/src/backend/core/src/rbac/models.rs
+++ b/src/backend/core/src/rbac/models.rs
@@ -1,0 +1,531 @@
+//! RBAC data models: Role, Permission, User identity, Organization, and bindings.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fmt;
+use uuid::Uuid;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Identifiers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Strongly-typed user identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct UserId(pub String);
+
+impl UserId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for UserId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for UserId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for UserId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Strongly-typed role identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RoleId(pub String);
+
+impl RoleId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RoleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for RoleId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for RoleId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Strongly-typed organization identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct OrganizationId(pub String);
+
+impl OrganizationId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn from_uuid() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+}
+
+impl fmt::Display for OrganizationId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for OrganizationId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for OrganizationId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Permission
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// A permission represents an action on a resource type.
+///
+/// Permissions follow the format `resource:action`, for example:
+/// - `swarm:create`
+/// - `agent:manage`
+/// - `task:submit`
+/// - `approval:approve`
+/// - `settings:manage`
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Permission {
+    /// The resource type (e.g., "swarm", "agent", "task").
+    pub resource: String,
+    /// The action (e.g., "create", "read", "delete", "manage").
+    pub action: String,
+}
+
+impl Permission {
+    /// Create a new permission.
+    pub fn new(resource: impl Into<String>, action: impl Into<String>) -> Self {
+        Self {
+            resource: resource.into(),
+            action: action.into(),
+        }
+    }
+
+    /// Parse a permission from a colon-separated string like `"swarm:create"`.
+    pub fn parse(s: &str) -> Option<Self> {
+        let parts: Vec<&str> = s.splitn(2, ':').collect();
+        if parts.len() == 2 {
+            Some(Self::new(parts[0], parts[1]))
+        } else {
+            None
+        }
+    }
+
+    /// Return the canonical string form `"resource:action"`.
+    pub fn as_string(&self) -> String {
+        format!("{}:{}", self.resource, self.action)
+    }
+
+    /// Check if this permission matches another, supporting wildcards.
+    ///
+    /// A wildcard `"*"` in either resource or action matches anything.
+    pub fn matches(&self, other: &Permission) -> bool {
+        let resource_match =
+            self.resource == "*" || other.resource == "*" || self.resource == other.resource;
+        let action_match =
+            self.action == "*" || other.action == "*" || self.action == other.action;
+        resource_match && action_match
+    }
+}
+
+impl fmt::Display for Permission {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.resource, self.action)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Role
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// A role groups a set of permissions under a named identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Role {
+    /// Unique role identifier.
+    pub id: RoleId,
+    /// Human-readable name.
+    pub name: String,
+    /// Description of the role's purpose.
+    pub description: String,
+    /// Set of permissions granted by this role.
+    pub permissions: HashSet<Permission>,
+    /// Whether this is a built-in system role (cannot be deleted).
+    pub is_system: bool,
+    /// Optional organization scope (None = global role).
+    pub organization_id: Option<OrganizationId>,
+    /// When the role was created.
+    pub created_at: DateTime<Utc>,
+    /// When the role was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Role {
+    /// Create a new role with the given permissions.
+    pub fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        permissions: HashSet<Permission>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: RoleId::new(id),
+            name: name.into(),
+            description: description.into(),
+            permissions,
+            is_system: false,
+            organization_id: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Mark this as a system role.
+    pub fn system(mut self) -> Self {
+        self.is_system = true;
+        self
+    }
+
+    /// Scope this role to an organization.
+    pub fn with_organization(mut self, org_id: OrganizationId) -> Self {
+        self.organization_id = Some(org_id);
+        self
+    }
+
+    /// Check if this role grants a specific permission.
+    pub fn has_permission(&self, permission: &Permission) -> bool {
+        self.permissions.iter().any(|p| p.matches(permission))
+    }
+
+    /// Add a permission to this role.
+    pub fn grant(&mut self, permission: Permission) {
+        self.permissions.insert(permission);
+        self.updated_at = Utc::now();
+    }
+
+    /// Remove a permission from this role.
+    pub fn revoke(&mut self, permission: &Permission) -> bool {
+        let removed = self.permissions.remove(permission);
+        if removed {
+            self.updated_at = Utc::now();
+        }
+        removed
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Role Binding
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Binds a user to a role within an organization scope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleBinding {
+    /// The user this binding applies to.
+    pub user_id: UserId,
+    /// The role being assigned.
+    pub role_id: RoleId,
+    /// Organization scope for this binding.
+    pub organization_id: OrganizationId,
+    /// When the binding was created.
+    pub created_at: DateTime<Utc>,
+    /// When the binding expires (None = never).
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Who granted this binding.
+    pub granted_by: Option<UserId>,
+}
+
+impl RoleBinding {
+    /// Create a new role binding.
+    pub fn new(
+        user_id: UserId,
+        role_id: RoleId,
+        organization_id: OrganizationId,
+    ) -> Self {
+        Self {
+            user_id,
+            role_id,
+            organization_id,
+            created_at: Utc::now(),
+            expires_at: None,
+            granted_by: None,
+        }
+    }
+
+    /// Set expiration.
+    pub fn with_expiry(mut self, expires_at: DateTime<Utc>) -> Self {
+        self.expires_at = Some(expires_at);
+        self
+    }
+
+    /// Record who granted this binding.
+    pub fn granted_by(mut self, user_id: UserId) -> Self {
+        self.granted_by = Some(user_id);
+        self
+    }
+
+    /// Check if this binding is currently active (not expired).
+    pub fn is_active(&self) -> bool {
+        self.expires_at.map_or(true, |exp| Utc::now() < exp)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Organization (Multi-Tenancy)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Organization status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrganizationStatus {
+    Active,
+    Suspended,
+    Deactivated,
+}
+
+/// An organization (tenant) that owns resources.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Organization {
+    pub id: OrganizationId,
+    pub name: String,
+    pub slug: String,
+    pub status: OrganizationStatus,
+    pub owner_id: UserId,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub settings: serde_json::Value,
+}
+
+impl Organization {
+    /// Create a new organization.
+    pub fn new(
+        name: impl Into<String>,
+        slug: impl Into<String>,
+        owner_id: UserId,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: OrganizationId::from_uuid(),
+            name: name.into(),
+            slug: slug.into(),
+            status: OrganizationStatus::Active,
+            owner_id,
+            created_at: now,
+            updated_at: now,
+            settings: serde_json::json!({}),
+        }
+    }
+
+    /// Check if the organization is active.
+    pub fn is_active(&self) -> bool {
+        self.status == OrganizationStatus::Active
+    }
+}
+
+/// Membership record linking a user to an organization with a role.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrganizationMember {
+    pub user_id: UserId,
+    pub organization_id: OrganizationId,
+    pub role: MemberRole,
+    pub joined_at: DateTime<Utc>,
+}
+
+/// Simple organization-level role (separate from RBAC roles for membership).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemberRole {
+    Owner,
+    Admin,
+    Member,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Resource Scope (tenant isolation)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Describes the scope of a resource for tenant isolation.
+///
+/// Every query against a tenant-scoped resource must include an
+/// `organization_id` filter to prevent cross-tenant data leakage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceScope {
+    /// The organization that owns this resource.
+    pub organization_id: OrganizationId,
+    /// Optional sub-scope (e.g., project, team).
+    pub project_id: Option<String>,
+}
+
+impl ResourceScope {
+    pub fn org(organization_id: OrganizationId) -> Self {
+        Self {
+            organization_id,
+            project_id: None,
+        }
+    }
+
+    pub fn project(organization_id: OrganizationId, project_id: impl Into<String>) -> Self {
+        Self {
+            organization_id,
+            project_id: Some(project_id.into()),
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_permission_parse() {
+        let perm = Permission::parse("swarm:create").unwrap();
+        assert_eq!(perm.resource, "swarm");
+        assert_eq!(perm.action, "create");
+        assert_eq!(perm.as_string(), "swarm:create");
+
+        assert!(Permission::parse("invalid").is_none());
+    }
+
+    #[test]
+    fn test_permission_matches_exact() {
+        let a = Permission::new("swarm", "create");
+        let b = Permission::new("swarm", "create");
+        assert!(a.matches(&b));
+    }
+
+    #[test]
+    fn test_permission_matches_wildcard() {
+        let wildcard = Permission::new("*", "*");
+        let specific = Permission::new("swarm", "create");
+        assert!(wildcard.matches(&specific));
+
+        let resource_wild = Permission::new("*", "create");
+        assert!(resource_wild.matches(&specific));
+
+        let action_wild = Permission::new("swarm", "*");
+        assert!(action_wild.matches(&specific));
+    }
+
+    #[test]
+    fn test_permission_no_match() {
+        let a = Permission::new("swarm", "create");
+        let b = Permission::new("agent", "manage");
+        assert!(!a.matches(&b));
+    }
+
+    #[test]
+    fn test_role_has_permission() {
+        let mut perms = HashSet::new();
+        perms.insert(Permission::new("swarm", "create"));
+        perms.insert(Permission::new("swarm", "read"));
+
+        let role = Role::new("editor", "Editor", "Can manage swarms", perms);
+
+        assert!(role.has_permission(&Permission::new("swarm", "create")));
+        assert!(role.has_permission(&Permission::new("swarm", "read")));
+        assert!(!role.has_permission(&Permission::new("swarm", "delete")));
+    }
+
+    #[test]
+    fn test_role_wildcard_permission() {
+        let mut perms = HashSet::new();
+        perms.insert(Permission::new("*", "*"));
+
+        let role = Role::new("superadmin", "Super Admin", "All access", perms);
+
+        assert!(role.has_permission(&Permission::new("swarm", "create")));
+        assert!(role.has_permission(&Permission::new("agent", "manage")));
+        assert!(role.has_permission(&Permission::new("settings", "manage")));
+    }
+
+    #[test]
+    fn test_role_grant_revoke() {
+        let mut role = Role::new("custom", "Custom", "Custom role", HashSet::new());
+
+        assert!(!role.has_permission(&Permission::new("swarm", "create")));
+
+        role.grant(Permission::new("swarm", "create"));
+        assert!(role.has_permission(&Permission::new("swarm", "create")));
+
+        let removed = role.revoke(&Permission::new("swarm", "create"));
+        assert!(removed);
+        assert!(!role.has_permission(&Permission::new("swarm", "create")));
+    }
+
+    #[test]
+    fn test_role_binding_active() {
+        let binding = RoleBinding::new(
+            UserId::new("user1"),
+            RoleId::new("admin"),
+            OrganizationId::new("org1"),
+        );
+        assert!(binding.is_active());
+
+        let expired = RoleBinding::new(
+            UserId::new("user2"),
+            RoleId::new("viewer"),
+            OrganizationId::new("org1"),
+        )
+        .with_expiry(Utc::now() - chrono::Duration::hours(1));
+        assert!(!expired.is_active());
+    }
+
+    #[test]
+    fn test_organization_creation() {
+        let org = Organization::new("Acme Corp", "acme-corp", UserId::new("user1"));
+        assert!(org.is_active());
+        assert_eq!(org.name, "Acme Corp");
+        assert_eq!(org.slug, "acme-corp");
+    }
+
+    #[test]
+    fn test_resource_scope() {
+        let scope = ResourceScope::org(OrganizationId::new("org1"));
+        assert_eq!(scope.organization_id.as_str(), "org1");
+        assert!(scope.project_id.is_none());
+
+        let scoped = ResourceScope::project(OrganizationId::new("org1"), "proj-a");
+        assert_eq!(scoped.project_id, Some("proj-a".to_string()));
+    }
+}

--- a/src/backend/core/src/rbac/policy.rs
+++ b/src/backend/core/src/rbac/policy.rs
@@ -1,0 +1,626 @@
+//! Policy engine for evaluating authorization decisions.
+//!
+//! The policy engine answers the question:
+//! "Can user X perform action Y on resource Z within organization O?"
+
+use dashmap::DashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+use thiserror::Error;
+use tracing::{debug, warn};
+
+use super::models::{
+    OrganizationId, Permission, Role, RoleBinding, RoleId, UserId,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Errors
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Errors from the policy engine.
+#[derive(Debug, Error)]
+pub enum PolicyError {
+    #[error("Role not found: {0}")]
+    RoleNotFound(String),
+
+    #[error("Organization not found: {0}")]
+    OrganizationNotFound(String),
+
+    #[error("User has no bindings in organization: user={user}, org={org}")]
+    NoBindings { user: String, org: String },
+
+    #[error("Permission denied: {0}")]
+    PermissionDenied(String),
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Decision
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Result of a policy evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyDecision {
+    /// The action is allowed.
+    Allow,
+    /// The action is denied, with a reason.
+    Deny(String),
+}
+
+impl PolicyDecision {
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allow)
+    }
+
+    pub fn is_denied(&self) -> bool {
+        matches!(self, Self::Deny(_))
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Policy Engine
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// The central policy engine that stores roles and bindings and evaluates
+/// authorization checks.
+///
+/// Thread-safe via `DashMap`.
+#[derive(Debug, Clone)]
+pub struct PolicyEngine {
+    /// Roles indexed by role id.
+    roles: Arc<DashMap<RoleId, Role>>,
+
+    /// User role bindings: key = (UserId, OrganizationId), value = set of RoleIds.
+    bindings: Arc<DashMap<(UserId, OrganizationId), HashSet<RoleId>>>,
+}
+
+impl PolicyEngine {
+    /// Create an empty policy engine.
+    pub fn new() -> Self {
+        Self {
+            roles: Arc::new(DashMap::new()),
+            bindings: Arc::new(DashMap::new()),
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Role management
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Register a role.
+    pub fn add_role(&self, role: Role) {
+        debug!(role_id = %role.id, "Adding role to policy engine");
+        self.roles.insert(role.id.clone(), role);
+    }
+
+    /// Load multiple roles (e.g., predefined defaults).
+    pub fn load_roles(&self, roles: Vec<Role>) {
+        for role in roles {
+            self.add_role(role);
+        }
+    }
+
+    /// Get a role by id.
+    pub fn get_role(&self, role_id: &RoleId) -> Option<Role> {
+        self.roles.get(role_id).map(|r| r.clone())
+    }
+
+    /// Remove a role. Returns `false` if the role is a system role or not found.
+    pub fn remove_role(&self, role_id: &RoleId) -> bool {
+        if let Some(role) = self.roles.get(role_id) {
+            if role.is_system {
+                warn!(role_id = %role_id, "Cannot remove system role");
+                return false;
+            }
+        }
+        self.roles.remove(role_id).is_some()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Binding management
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Bind a user to a role within an organization.
+    pub fn bind_role(&self, binding: RoleBinding) {
+        if !binding.is_active() {
+            debug!(
+                user_id = %binding.user_id,
+                role_id = %binding.role_id,
+                "Skipping expired binding"
+            );
+            return;
+        }
+
+        let key = (binding.user_id.clone(), binding.organization_id.clone());
+        self.bindings
+            .entry(key)
+            .or_insert_with(HashSet::new)
+            .insert(binding.role_id);
+    }
+
+    /// Remove a user's binding to a role in an organization.
+    pub fn unbind_role(
+        &self,
+        user_id: &UserId,
+        role_id: &RoleId,
+        organization_id: &OrganizationId,
+    ) -> bool {
+        let key = (user_id.clone(), organization_id.clone());
+        if let Some(mut role_ids) = self.bindings.get_mut(&key) {
+            role_ids.remove(role_id)
+        } else {
+            false
+        }
+    }
+
+    /// Get all role IDs bound to a user in a specific organization.
+    pub fn user_roles(
+        &self,
+        user_id: &UserId,
+        organization_id: &OrganizationId,
+    ) -> HashSet<RoleId> {
+        let key = (user_id.clone(), organization_id.clone());
+        self.bindings
+            .get(&key)
+            .map(|r| r.clone())
+            .unwrap_or_default()
+    }
+
+    /// Get all effective permissions for a user in an organization.
+    pub fn effective_permissions(
+        &self,
+        user_id: &UserId,
+        organization_id: &OrganizationId,
+    ) -> HashSet<Permission> {
+        let role_ids = self.user_roles(user_id, organization_id);
+        let mut perms = HashSet::new();
+
+        for role_id in &role_ids {
+            if let Some(role) = self.roles.get(role_id) {
+                perms.extend(role.permissions.iter().cloned());
+            }
+        }
+
+        perms
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Authorization checks
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Check if a user has a specific permission within an organization.
+    ///
+    /// Returns a `PolicyDecision` indicating allow or deny.
+    pub fn check(
+        &self,
+        user_id: &UserId,
+        permission: &Permission,
+        organization_id: &OrganizationId,
+    ) -> PolicyDecision {
+        let role_ids = self.user_roles(user_id, organization_id);
+
+        if role_ids.is_empty() {
+            return PolicyDecision::Deny(format!(
+                "User {} has no roles in organization {}",
+                user_id, organization_id
+            ));
+        }
+
+        for role_id in &role_ids {
+            if let Some(role) = self.roles.get(role_id) {
+                if role.has_permission(permission) {
+                    debug!(
+                        user_id = %user_id,
+                        permission = %permission,
+                        role = %role_id,
+                        "Permission granted"
+                    );
+                    return PolicyDecision::Allow;
+                }
+            }
+        }
+
+        PolicyDecision::Deny(format!(
+            "User {} does not have permission {} in organization {}",
+            user_id, permission, organization_id
+        ))
+    }
+
+    /// Convenience: returns `Ok(())` if allowed, `Err(PolicyError)` if denied.
+    pub fn enforce(
+        &self,
+        user_id: &UserId,
+        permission: &Permission,
+        organization_id: &OrganizationId,
+    ) -> Result<(), PolicyError> {
+        match self.check(user_id, permission, organization_id) {
+            PolicyDecision::Allow => Ok(()),
+            PolicyDecision::Deny(reason) => Err(PolicyError::PermissionDenied(reason)),
+        }
+    }
+
+    /// Check multiple permissions; returns `Allow` only if ALL are granted.
+    pub fn check_all(
+        &self,
+        user_id: &UserId,
+        permissions: &[Permission],
+        organization_id: &OrganizationId,
+    ) -> PolicyDecision {
+        for perm in permissions {
+            let decision = self.check(user_id, perm, organization_id);
+            if decision.is_denied() {
+                return decision;
+            }
+        }
+        PolicyDecision::Allow
+    }
+
+    /// Check multiple permissions; returns `Allow` if ANY is granted.
+    pub fn check_any(
+        &self,
+        user_id: &UserId,
+        permissions: &[Permission],
+        organization_id: &OrganizationId,
+    ) -> PolicyDecision {
+        for perm in permissions {
+            if self.check(user_id, perm, organization_id).is_allowed() {
+                return PolicyDecision::Allow;
+            }
+        }
+        PolicyDecision::Deny(format!(
+            "User {} does not have any of the required permissions in organization {}",
+            user_id, organization_id
+        ))
+    }
+}
+
+impl Default for PolicyEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rbac::roles::PredefinedRole;
+
+    fn setup_engine() -> PolicyEngine {
+        let engine = PolicyEngine::new();
+        engine.load_roles(PredefinedRole::all_defaults());
+        engine
+    }
+
+    fn org(id: &str) -> OrganizationId {
+        OrganizationId::new(id)
+    }
+
+    fn user(id: &str) -> UserId {
+        UserId::new(id)
+    }
+
+    fn bind(engine: &PolicyEngine, uid: &str, role: &str, oid: &str) {
+        engine.bind_role(RoleBinding::new(
+            UserId::new(uid),
+            RoleId::new(role),
+            OrganizationId::new(oid),
+        ));
+    }
+
+    #[test]
+    fn test_admin_allowed_everything() {
+        let engine = setup_engine();
+        bind(&engine, "alice", "admin", "org1");
+
+        assert!(engine
+            .check(
+                &user("alice"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_allowed());
+        assert!(engine
+            .check(
+                &user("alice"),
+                &Permission::new("settings", "manage"),
+                &org("org1"),
+            )
+            .is_allowed());
+        assert!(engine
+            .check(
+                &user("alice"),
+                &Permission::new("anything", "goes"),
+                &org("org1"),
+            )
+            .is_allowed());
+    }
+
+    #[test]
+    fn test_viewer_read_only() {
+        let engine = setup_engine();
+        bind(&engine, "bob", "viewer", "org1");
+
+        assert!(engine
+            .check(
+                &user("bob"),
+                &Permission::new("swarm", "read"),
+                &org("org1"),
+            )
+            .is_allowed());
+
+        assert!(engine
+            .check(
+                &user("bob"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_denied());
+
+        assert!(engine
+            .check(
+                &user("bob"),
+                &Permission::new("settings", "manage"),
+                &org("org1"),
+            )
+            .is_denied());
+    }
+
+    #[test]
+    fn test_operator_cannot_manage_settings() {
+        let engine = setup_engine();
+        bind(&engine, "charlie", "operator", "org1");
+
+        assert!(engine
+            .check(
+                &user("charlie"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_allowed());
+
+        assert!(engine
+            .check(
+                &user("charlie"),
+                &Permission::new("approval", "approve"),
+                &org("org1"),
+            )
+            .is_allowed());
+
+        assert!(engine
+            .check(
+                &user("charlie"),
+                &Permission::new("settings", "manage"),
+                &org("org1"),
+            )
+            .is_denied());
+    }
+
+    #[test]
+    fn test_developer_cannot_delete_swarms() {
+        let engine = setup_engine();
+        bind(&engine, "dave", "developer", "org1");
+
+        assert!(engine
+            .check(
+                &user("dave"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_allowed());
+
+        assert!(engine
+            .check(
+                &user("dave"),
+                &Permission::new("swarm", "delete"),
+                &org("org1"),
+            )
+            .is_denied());
+    }
+
+    #[test]
+    fn test_no_roles_denied() {
+        let engine = setup_engine();
+
+        assert!(engine
+            .check(
+                &user("nobody"),
+                &Permission::new("swarm", "read"),
+                &org("org1"),
+            )
+            .is_denied());
+    }
+
+    #[test]
+    fn test_tenant_isolation() {
+        let engine = setup_engine();
+        bind(&engine, "alice", "admin", "org1");
+
+        // Alice is admin in org1, but has no access in org2.
+        assert!(engine
+            .check(
+                &user("alice"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_allowed());
+
+        assert!(engine
+            .check(
+                &user("alice"),
+                &Permission::new("swarm", "create"),
+                &org("org2"),
+            )
+            .is_denied());
+    }
+
+    #[test]
+    fn test_multiple_roles() {
+        let engine = setup_engine();
+        bind(&engine, "eve", "viewer", "org1");
+        bind(&engine, "eve", "developer", "org1");
+
+        // Eve gets combined permissions from both roles.
+        assert!(engine
+            .check(
+                &user("eve"),
+                &Permission::new("swarm", "read"),
+                &org("org1"),
+            )
+            .is_allowed());
+        assert!(engine
+            .check(
+                &user("eve"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_allowed());
+        // But still no settings:manage
+        assert!(engine
+            .check(
+                &user("eve"),
+                &Permission::new("settings", "manage"),
+                &org("org1"),
+            )
+            .is_denied());
+    }
+
+    #[test]
+    fn test_enforce() {
+        let engine = setup_engine();
+        bind(&engine, "alice", "admin", "org1");
+
+        assert!(engine
+            .enforce(
+                &user("alice"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_ok());
+
+        assert!(engine
+            .enforce(
+                &user("nobody"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn test_check_all() {
+        let engine = setup_engine();
+        bind(&engine, "alice", "operator", "org1");
+
+        let perms = vec![
+            Permission::new("swarm", "create"),
+            Permission::new("swarm", "read"),
+        ];
+        assert!(engine
+            .check_all(&user("alice"), &perms, &org("org1"))
+            .is_allowed());
+
+        let perms_with_settings = vec![
+            Permission::new("swarm", "create"),
+            Permission::new("settings", "manage"),
+        ];
+        assert!(engine
+            .check_all(&user("alice"), &perms_with_settings, &org("org1"))
+            .is_denied());
+    }
+
+    #[test]
+    fn test_check_any() {
+        let engine = setup_engine();
+        bind(&engine, "bob", "viewer", "org1");
+
+        let perms = vec![
+            Permission::new("swarm", "create"),
+            Permission::new("swarm", "read"),
+        ];
+        assert!(engine
+            .check_any(&user("bob"), &perms, &org("org1"))
+            .is_allowed());
+
+        let perms_write = vec![
+            Permission::new("swarm", "create"),
+            Permission::new("swarm", "delete"),
+        ];
+        assert!(engine
+            .check_any(&user("bob"), &perms_write, &org("org1"))
+            .is_denied());
+    }
+
+    #[test]
+    fn test_unbind_role() {
+        let engine = setup_engine();
+        bind(&engine, "alice", "admin", "org1");
+
+        assert!(engine
+            .check(
+                &user("alice"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_allowed());
+
+        let removed = engine.unbind_role(
+            &user("alice"),
+            &RoleId::new("admin"),
+            &org("org1"),
+        );
+        assert!(removed);
+
+        assert!(engine
+            .check(
+                &user("alice"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_denied());
+    }
+
+    #[test]
+    fn test_effective_permissions() {
+        let engine = setup_engine();
+        bind(&engine, "eve", "viewer", "org1");
+        bind(&engine, "eve", "developer", "org1");
+
+        let perms = engine.effective_permissions(&user("eve"), &org("org1"));
+        assert!(perms.contains(&Permission::new("swarm", "read")));
+        assert!(perms.contains(&Permission::new("swarm", "create")));
+        assert!(perms.contains(&Permission::new("task", "submit")));
+    }
+
+    #[test]
+    fn test_expired_binding_ignored() {
+        let engine = setup_engine();
+        let expired = RoleBinding::new(
+            UserId::new("alice"),
+            RoleId::new("admin"),
+            OrganizationId::new("org1"),
+        )
+        .with_expiry(chrono::Utc::now() - chrono::Duration::hours(1));
+
+        engine.bind_role(expired);
+
+        assert!(engine
+            .check(
+                &user("alice"),
+                &Permission::new("swarm", "create"),
+                &org("org1"),
+            )
+            .is_denied());
+    }
+
+    #[test]
+    fn test_cannot_remove_system_role() {
+        let engine = setup_engine();
+        let removed = engine.remove_role(&RoleId::new("admin"));
+        assert!(!removed);
+        // System role should still exist
+        assert!(engine.get_role(&RoleId::new("admin")).is_some());
+    }
+}

--- a/src/backend/core/src/rbac/roles.rs
+++ b/src/backend/core/src/rbac/roles.rs
@@ -1,0 +1,186 @@
+//! Predefined roles with default permission sets.
+//!
+//! Apex ships with four built-in roles:
+//!
+//! | Role       | Description                                                  |
+//! |------------|--------------------------------------------------------------|
+//! | Admin      | Full access to all resources and settings                     |
+//! | Operator   | Manage swarms, agents, and tasks; approve actions             |
+//! | Developer  | Create and manage swarms and tasks; cannot change settings    |
+//! | Viewer     | Read-only access to all resources                            |
+
+use std::collections::HashSet;
+
+use super::models::{Permission, Role, RoleId};
+
+/// Predefined role templates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PredefinedRole {
+    Admin,
+    Operator,
+    Developer,
+    Viewer,
+}
+
+impl PredefinedRole {
+    /// Get the role identifier string.
+    pub fn id(&self) -> &'static str {
+        match self {
+            Self::Admin => "admin",
+            Self::Operator => "operator",
+            Self::Developer => "developer",
+            Self::Viewer => "viewer",
+        }
+    }
+
+    /// Get the human-readable name.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Admin => "Admin",
+            Self::Operator => "Operator",
+            Self::Developer => "Developer",
+            Self::Viewer => "Viewer",
+        }
+    }
+
+    /// Get the description.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Admin => "Full access to all resources and organization settings",
+            Self::Operator => "Manage swarms, agents, and tasks; approve actions",
+            Self::Developer => "Create and manage swarms and tasks",
+            Self::Viewer => "Read-only access to all resources",
+        }
+    }
+
+    /// Return the set of permissions for this predefined role.
+    pub fn permissions(&self) -> HashSet<Permission> {
+        match self {
+            Self::Admin => {
+                // Admin gets wildcard: all resources, all actions.
+                let mut perms = HashSet::new();
+                perms.insert(Permission::new("*", "*"));
+                perms
+            }
+            Self::Operator => {
+                let mut perms = HashSet::new();
+                perms.insert(Permission::new("swarm", "create"));
+                perms.insert(Permission::new("swarm", "read"));
+                perms.insert(Permission::new("swarm", "delete"));
+                perms.insert(Permission::new("agent", "manage"));
+                perms.insert(Permission::new("task", "submit"));
+                perms.insert(Permission::new("task", "read"));
+                perms.insert(Permission::new("approval", "approve"));
+                // Operator cannot manage settings
+                perms
+            }
+            Self::Developer => {
+                let mut perms = HashSet::new();
+                perms.insert(Permission::new("swarm", "create"));
+                perms.insert(Permission::new("swarm", "read"));
+                perms.insert(Permission::new("agent", "manage"));
+                perms.insert(Permission::new("task", "submit"));
+                perms.insert(Permission::new("task", "read"));
+                // Developer cannot delete swarms, approve, or manage settings
+                perms
+            }
+            Self::Viewer => {
+                let mut perms = HashSet::new();
+                perms.insert(Permission::new("swarm", "read"));
+                perms.insert(Permission::new("agent", "read"));
+                perms.insert(Permission::new("task", "read"));
+                perms.insert(Permission::new("approval", "read"));
+                perms.insert(Permission::new("settings", "read"));
+                perms
+            }
+        }
+    }
+
+    /// Build a full `Role` struct from this predefined role.
+    pub fn to_role(&self) -> Role {
+        Role::new(
+            self.id(),
+            self.name(),
+            self.description(),
+            self.permissions(),
+        )
+        .system()
+    }
+
+    /// Return all predefined roles.
+    pub fn all() -> Vec<PredefinedRole> {
+        vec![
+            Self::Admin,
+            Self::Operator,
+            Self::Developer,
+            Self::Viewer,
+        ]
+    }
+
+    /// Return all predefined roles as `Role` structs.
+    pub fn all_defaults() -> Vec<Role> {
+        Self::all().into_iter().map(|r| r.to_role()).collect()
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_admin_has_wildcard() {
+        let role = PredefinedRole::Admin.to_role();
+        assert!(role.has_permission(&Permission::new("swarm", "create")));
+        assert!(role.has_permission(&Permission::new("settings", "manage")));
+        assert!(role.has_permission(&Permission::new("anything", "anything")));
+    }
+
+    #[test]
+    fn test_operator_permissions() {
+        let role = PredefinedRole::Operator.to_role();
+        assert!(role.has_permission(&Permission::new("swarm", "create")));
+        assert!(role.has_permission(&Permission::new("swarm", "delete")));
+        assert!(role.has_permission(&Permission::new("approval", "approve")));
+        assert!(!role.has_permission(&Permission::new("settings", "manage")));
+    }
+
+    #[test]
+    fn test_developer_permissions() {
+        let role = PredefinedRole::Developer.to_role();
+        assert!(role.has_permission(&Permission::new("swarm", "create")));
+        assert!(role.has_permission(&Permission::new("task", "submit")));
+        assert!(!role.has_permission(&Permission::new("swarm", "delete")));
+        assert!(!role.has_permission(&Permission::new("settings", "manage")));
+        assert!(!role.has_permission(&Permission::new("approval", "approve")));
+    }
+
+    #[test]
+    fn test_viewer_read_only() {
+        let role = PredefinedRole::Viewer.to_role();
+        assert!(role.has_permission(&Permission::new("swarm", "read")));
+        assert!(role.has_permission(&Permission::new("agent", "read")));
+        assert!(role.has_permission(&Permission::new("task", "read")));
+        assert!(!role.has_permission(&Permission::new("swarm", "create")));
+        assert!(!role.has_permission(&Permission::new("swarm", "delete")));
+        assert!(!role.has_permission(&Permission::new("settings", "manage")));
+    }
+
+    #[test]
+    fn test_all_defaults() {
+        let roles = PredefinedRole::all_defaults();
+        assert_eq!(roles.len(), 4);
+        assert!(roles.iter().all(|r| r.is_system));
+    }
+
+    #[test]
+    fn test_role_ids() {
+        assert_eq!(PredefinedRole::Admin.id(), "admin");
+        assert_eq!(PredefinedRole::Operator.id(), "operator");
+        assert_eq!(PredefinedRole::Developer.id(), "developer");
+        assert_eq!(PredefinedRole::Viewer.id(), "viewer");
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces a complete role-based access control (RBAC) system with multi-tenancy support
- Adds four predefined roles (Admin, Operator, Developer, Viewer) with granular permissions: `swarm:create`, `swarm:read`, `swarm:delete`, `agent:manage`, `task:submit`, `approval:approve`, `settings:manage`, and read variants
- Implements a policy engine that evaluates per-organization role bindings with wildcard permission support, binding expiry, and system role protection
- Provides Axum `RequirePermissionLayer` middleware that integrates with the existing `AuthContext` to enforce permissions at the route level
- Adds database migration with organizations, users, roles, permissions, user_roles, role_permissions, and organization_members tables, including row-level security on the organizations table for tenant isolation
- Includes a comprehensive test suite covering permission matching, role grants/revokes, tenant isolation across organizations, expired binding handling, and policy enforcement

## New files

- `src/backend/core/src/rbac/mod.rs` - Module entry point and public API
- `src/backend/core/src/rbac/models.rs` - Permission, Role, RoleBinding, Organization, and ResourceScope models
- `src/backend/core/src/rbac/policy.rs` - PolicyEngine with check/enforce/check_all/check_any
- `src/backend/core/src/rbac/roles.rs` - Predefined role definitions
- `src/backend/core/src/rbac/middleware.rs` - Axum RequirePermissionLayer and RbacContext extractor
- `src/backend/core/migrations/20240101000004_rbac_tables.sql` - Database migration with seed data

## Test plan

- [ ] Verify all RBAC unit tests pass (`cargo test --lib rbac`)
- [ ] Confirm admin role has wildcard access to all resources
- [ ] Confirm viewer role is read-only (denied on create/delete/manage)
- [ ] Confirm tenant isolation: user with role in org1 is denied in org2
- [ ] Confirm expired role bindings are rejected
- [ ] Validate migration applies cleanly on a fresh PostgreSQL database
- [ ] Integration test: apply RequirePermissionLayer to a test route and verify 403 for unauthorized users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authorization and tenant-isolation foundations (permission enforcement middleware and new RLS-backed schema), so mistakes could cause cross-tenant access or unintended denials.
> 
> **Overview**
> Adds first-class **RBAC + multi-tenancy** support to `apex_core`, including a new `rbac` module (models, predefined roles, and an in-memory `PolicyEngine`) plus an Axum `RequirePermissionLayer` that enforces `resource:action` permissions per-request using `AuthContext` (incl. required `org_id`) and injects an `RbacContext` for handlers.
> 
> Introduces a new Postgres migration creating core tenant/RBAC tables (`organizations`, `users`, `roles`, `permissions`, `role_permissions`, `user_roles`, `organization_members`), seeds default permissions + system roles, adds updated-at triggers, and enables initial row-level security on `organizations` keyed off `app.current_org_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81026f21db5c1f6dc01ab48ab144c4db0c92df8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for organizations and multi-tenant environments.
  * Introduced role-based access control with predefined roles (Admin, Operator, Developer, Viewer).
  * Implemented authorization middleware to enforce permissions on protected resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->