### PR TITLE
Fix duplicate benchmark definitions blocking compilation

### DIFF
--- a/src/backend/core/Cargo.toml
+++ b/src/backend/core/Cargo.toml
@@ -120,21 +120,6 @@ harness = false
 [[bench]]
 name = "validation_bench"
 harness = false
-[[bench]]
-name = "dag_bench"
-harness = false
-
-[[bench]]
-name = "routing_bench"
-harness = false
-
-[[bench]]
-name = "cache_bench"
-harness = false
-
-[[bench]]
-name = "validation_bench"
-harness = false
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Remove duplicate [[bench]] entries that prevent cargo build/test from working