### PR TITLE
Extract shared JS utilities, remove duplicates

### DIFF
--- a/src/backend/core/static/app.js
+++ b/src/backend/core/static/app.js
@@ -533,58 +533,7 @@
     textEl.innerHTML = renderMarkdown(text);
   }
 
-  // NOTE: escapeHtml is called before any HTML transforms in renderMarkdown,
-  // ensuring user-provided text is sanitized before being inserted into the DOM.
-  function escapeHtml(str) {
-    const div = document.createElement("div");
-    div.textContent = str;
-    return div.innerHTML;
-  }
-
-  // renderMarkdown escapes ALL input via escapeHtml first, then applies
-  // safe formatting transforms on the already-escaped string.
-  function renderMarkdown(text) {
-    if (!text) return "";
-    let html = escapeHtml(text);
-
-    html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
-      return '<pre><code class="language-' + lang + '">' + code.trim() + "</code></pre>";
-    });
-    html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
-    // Tables: consecutive lines starting/ending with |
-    html = html.replace(/(^\|.+\|[ \t]*$\n?)+/gm, function(block) {
-      var rows = block.trim().split('\n');
-      if (rows.length < 2) return block;
-      if (!/^\|[\s\-:]+\|$/.test(rows[1])) return block;
-      var pr = function(r) { return r.split('|').slice(1, -1).map(function(c) { return c.trim(); }); };
-      var hds = pr(rows[0]);
-      var t = '<table><thead><tr>' + hds.map(function(c) { return '<th>' + c + '</th>'; }).join('') + '</tr></thead><tbody>';
-      for (var i = 2; i < rows.length; i++) {
-        var cells = pr(rows[i]);
-        t += '<tr>' + cells.map(function(c) { return '<td>' + c + '</td>'; }).join('') + '</tr>';
-      }
-      return t + '</tbody></table>';
-    });
-    // Blockquotes (> is escaped to &gt; by escapeHtml)
-    html = html.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
-    html = html.replace(/<\/blockquote>\n<blockquote>/g, '<br/>');
-    // Horizontal rules
-    html = html.replace(/^-{3,}$/gm, '<hr/>');
-    html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-    html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
-    html = html.replace(/^### (.+)$/gm, "<h4>$1</h4>");
-    html = html.replace(/^## (.+)$/gm, "<h3>$1</h3>");
-    html = html.replace(/^# (.+)$/gm, "<h2>$1</h2>");
-    html = html.replace(/^\s*[-*] (.+)$/gm, "<li>$1</li>");
-    html = html.replace(/(<li>.*<\/li>\n?)+/g, (match) => "<ul>" + match + "</ul>");
-    html = html.replace(/^\s*\d+\. (.+)$/gm, "<li>$1</li>");
-    html = html.replace(/\n\n/g, "</p><p>");
-    html = html.replace(/\n/g, "<br/>");
-    if (!html.startsWith("<")) {
-      html = "<p>" + html + "</p>";
-    }
-    return html;
-  }
+  // escapeHtml and renderMarkdown are provided by utils.js (loaded before this script)
 
   function scrollToBottom() {
     requestAnimationFrame(() => {

--- a/src/backend/core/static/index.html
+++ b/src/backend/core/static/index.html
@@ -216,6 +216,7 @@
       </div>
     </div>
 
+    <script src="/static/utils.js?v=15"></script>
     <script src="/static/swarm.js?v=15"></script>
     <script src="/static/app.js?v=15"></script>
   </body>

--- a/src/backend/core/static/swarm.js
+++ b/src/backend/core/static/swarm.js
@@ -30,53 +30,7 @@
     chapter_writing: 'Chapters', stitching: 'Stitching', rendering: 'Rendering'
   };
 
-  // NOTE: escapeHtml is called before any HTML transforms in renderMarkdown,
-  // ensuring user-provided text is sanitized before being inserted into the DOM.
-  function escapeHtml(str) {
-    const d = document.createElement("div");
-    d.textContent = str;
-    return d.innerHTML;
-  }
-
-  // renderMarkdown escapes ALL input via escapeHtml first, then applies
-  // safe formatting transforms on the already-escaped string.
-  function renderMarkdown(text) {
-    if (!text) return "";
-    let h = escapeHtml(text);
-    h = h.replace(/```(\w*)\n([\s\S]*?)```/g, (_, l, c) => `<pre><code class="language-${l}">${c.trim()}</code></pre>`);
-    h = h.replace(/`([^`]+)`/g, "<code>$1</code>");
-    // Tables: consecutive lines starting/ending with |
-    h = h.replace(/(^\|.+\|[ \t]*$\n?)+/gm, function(block) {
-      const rows = block.trim().split('\n');
-      if (rows.length < 2) return block;
-      if (!/^\|[\s\-:]+\|$/.test(rows[1])) return block;
-      const pr = (r) => r.split('|').slice(1, -1).map(c => c.trim());
-      const hds = pr(rows[0]);
-      let t = '<table><thead><tr>' + hds.map(c => '<th>' + c + '</th>').join('') + '</tr></thead><tbody>';
-      for (let i = 2; i < rows.length; i++) {
-        const cells = pr(rows[i]);
-        t += '<tr>' + cells.map(c => '<td>' + c + '</td>').join('') + '</tr>';
-      }
-      return t + '</tbody></table>';
-    });
-    // Blockquotes (> is escaped to &gt; by escapeHtml)
-    h = h.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
-    h = h.replace(/<\/blockquote>\n<blockquote>/g, '<br/>');
-    // Horizontal rules
-    h = h.replace(/^-{3,}$/gm, '<hr/>');
-    h = h.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-    h = h.replace(/\*(.+?)\*/g, "<em>$1</em>");
-    h = h.replace(/^### (.+)$/gm, "<h4>$1</h4>");
-    h = h.replace(/^## (.+)$/gm, "<h3>$1</h3>");
-    h = h.replace(/^# (.+)$/gm, "<h2>$1</h2>");
-    h = h.replace(/^\s*[-*] (.+)$/gm, "<li>$1</li>");
-    h = h.replace(/(<li>.*<\/li>\n?)+/g, (m) => `<ul>${m}</ul>`);
-    h = h.replace(/^\s*\d+\. (.+)$/gm, "<li>$1</li>");
-    h = h.replace(/\n\n/g, "</p><p>");
-    h = h.replace(/\n/g, "<br/>");
-    if (!h.startsWith("<")) h = `<p>${h}</p>`;
-    return h;
-  }
+  // escapeHtml and renderMarkdown are provided by utils.js (loaded before this script)
 
   // ── WebSocket client ──
   class SwarmClient {

--- a/src/backend/core/static/utils.js
+++ b/src/backend/core/static/utils.js
@@ -1,0 +1,54 @@
+// Shared utility functions used by both app.js and swarm.js
+
+// NOTE: escapeHtml is called before any HTML transforms in renderMarkdown,
+// ensuring user-provided text is sanitized before being inserted into the DOM.
+function escapeHtml(str) {
+  const div = document.createElement("div");
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+// renderMarkdown escapes ALL input via escapeHtml first, then applies
+// safe formatting transforms on the already-escaped string.
+function renderMarkdown(text) {
+  if (!text) return "";
+  let html = escapeHtml(text);
+
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
+    return '<pre><code class="language-' + lang + '">' + code.trim() + "</code></pre>";
+  });
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+  // Tables: consecutive lines starting/ending with |
+  html = html.replace(/(^\|.+\|[ \t]*$\n?)+/gm, function(block) {
+    var rows = block.trim().split('\n');
+    if (rows.length < 2) return block;
+    if (!/^\|[\s\-:]+\|$/.test(rows[1])) return block;
+    var pr = function(r) { return r.split('|').slice(1, -1).map(function(c) { return c.trim(); }); };
+    var hds = pr(rows[0]);
+    var t = '<table><thead><tr>' + hds.map(function(c) { return '<th>' + c + '</th>'; }).join('') + '</tr></thead><tbody>';
+    for (var i = 2; i < rows.length; i++) {
+      var cells = pr(rows[i]);
+      t += '<tr>' + cells.map(function(c) { return '<td>' + c + '</td>'; }).join('') + '</tr>';
+    }
+    return t + '</tbody></table>';
+  });
+  // Blockquotes (> is escaped to &gt; by escapeHtml)
+  html = html.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
+  html = html.replace(/<\/blockquote>\n<blockquote>/g, '<br/>');
+  // Horizontal rules
+  html = html.replace(/^-{3,}$/gm, '<hr/>');
+  html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
+  html = html.replace(/^### (.+)$/gm, "<h4>$1</h4>");
+  html = html.replace(/^## (.+)$/gm, "<h3>$1</h3>");
+  html = html.replace(/^# (.+)$/gm, "<h2>$1</h2>");
+  html = html.replace(/^\s*[-*] (.+)$/gm, "<li>$1</li>");
+  html = html.replace(/(<li>.*<\/li>\n?)+/g, (match) => "<ul>" + match + "</ul>");
+  html = html.replace(/^\s*\d+\. (.+)$/gm, "<li>$1</li>");
+  html = html.replace(/\n\n/g, "</p><p>");
+  html = html.replace(/\n/g, "<br/>");
+  if (!html.startsWith("<")) {
+    html = "<p>" + html + "</p>";
+  }
+  return html;
+}


### PR DESCRIPTION
Closes #24

Moves escapeHtml and renderMarkdown to shared utils.js, removes duplicate copies from app.js and swarm.js.