### PR TITLE
Add __main__.py entry point for FastAPI app

### DIFF
--- a/src/backend/core/__main__.py
+++ b/src/backend/core/__main__.py
@@ -1,0 +1,15 @@
+"""Entry point for running the Apex FastAPI application."""
+
+import os
+
+import uvicorn
+
+from .app import app  # noqa: F401
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "src.backend.core.app:app",
+        host=os.getenv("APEX_HOST", "0.0.0.0"),
+        port=int(os.getenv("APEX_PORT", "8000")),
+        reload=os.getenv("APEX_RELOAD", "").lower() in ("1", "true", "yes"),
+    )


### PR DESCRIPTION
## Summary
- Adds `src/backend/core/__main__.py` so the app can be started with `python -m src.backend.core`
- Configurable via `APEX_HOST`, `APEX_PORT`, `APEX_RELOAD` env vars

Fixes #32