### PR TITLE
Load .env and make FIRECRAWL_BASE_URL configurable

### DIFF
--- a/src/backend/core/config.py
+++ b/src/backend/core/config.py
@@ -3,6 +3,10 @@
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 # MiniMax API
 MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY", "")
 
@@ -18,7 +22,7 @@ SWARM_DEFAULTS = {
 }
 
 # Firecrawl web search API
-FIRECRAWL_BASE_URL = "https://api-production-91c7.up.railway.app"
+FIRECRAWL_BASE_URL = os.getenv("FIRECRAWL_BASE_URL", "https://api-production-91c7.up.railway.app")
 
 # Persistent storage for completed swarm reports
 DATA_DIR = Path(__file__).resolve().parent.parent.parent.parent / "data"


### PR DESCRIPTION
## Summary
- Calls `load_dotenv()` before `os.getenv()` so `.env` is actually loaded
- Makes `FIRECRAWL_BASE_URL` configurable via env var with existing URL as default

Fixes #33, fixes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced configuration management to support environment variables for service configuration, allowing greater flexibility across different deployment environments while maintaining backward compatibility with existing defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->