### PR TITLE
Switch from MiniMax to Claude API

### DIFF
--- a/src/backend/core/app.py
+++ b/src/backend/core/app.py
@@ -1,4 +1,4 @@
-"""Apex — MiniMax-M2.5 Chat Application (FastAPI backend)."""
+"""Apex — Claude-powered Agent Swarm (FastAPI backend)."""
 
 from __future__ import annotations
 
@@ -17,10 +17,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from .config import (
+    ANTHROPIC_API_KEY,
+    ANTHROPIC_BASE_URL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_TEMPERATURE,
-    MINIMAX_API_KEY,
-    MINIMAX_BASE_URL,
     MODEL_NAME,
     REPORTS_DIR,
 )
@@ -42,7 +42,7 @@ def _validate_report_id(report_id: str) -> bool:
 
 STATIC_DIR = Path(__file__).parent / "static"
 
-app = FastAPI(title="Apex — MiniMax-M2.5")
+app = FastAPI(title="Apex — Claude Agent Swarm")
 
 app.add_middleware(
     CORSMiddleware,
@@ -73,48 +73,73 @@ async def index() -> HTMLResponse:
 
 @app.post("/api/chat")
 async def chat(request: Request) -> StreamingResponse:
-    """Proxy user messages to the MiniMax API with SSE streaming."""
+    """Proxy user messages to the Claude API with SSE streaming."""
     body = await request.json()
     messages: list[dict] = body.get("messages", [])
 
-    payload = {
+    # Extract system message for Anthropic format
+    system_prompt = ""
+    anthropic_msgs = []
+    for msg in messages:
+        if msg["role"] == "system":
+            system_prompt = msg["content"]
+        else:
+            anthropic_msgs.append({"role": msg["role"], "content": msg["content"]})
+
+    payload: dict = {
         "model": MODEL_NAME,
-        "messages": messages,
+        "messages": anthropic_msgs,
         "stream": True,
         "max_tokens": DEFAULT_MAX_TOKENS,
         "temperature": DEFAULT_TEMPERATURE,
     }
+    if system_prompt:
+        payload["system"] = system_prompt
 
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {MINIMAX_API_KEY}",
+        "x-api-key": ANTHROPIC_API_KEY,
+        "anthropic-version": "2023-06-01",
     }
 
     async def event_stream() -> AsyncGenerator[str, None]:
         async with httpx.AsyncClient(timeout=120.0) as client:
             async with client.stream(
                 "POST",
-                f"{MINIMAX_BASE_URL}/chat/completions",
+                f"{ANTHROPIC_BASE_URL}/messages",
                 json=payload,
                 headers=headers,
             ) as resp:
                 if resp.status_code != 200:
                     error_body = await resp.aread()
                     error_msg = error_body.decode("utf-8", errors="replace")
-                    logger.error("MiniMax API error %s: %s", resp.status_code, error_msg)
+                    logger.error("Claude API error %s: %s", resp.status_code, error_msg)
                     yield f"data: {json.dumps({'error': error_msg})}\n\n"
                     return
 
                 async for line in resp.aiter_lines():
                     if not line:
                         continue
-                    # Forward SSE events as-is
                     if line.startswith("data:"):
                         data_str = line[len("data:"):].strip()
-                        if data_str == "[DONE]":
-                            yield "data: [DONE]\n\n"
-                            break
-                        yield f"data: {data_str}\n\n"
+                        try:
+                            event = json.loads(data_str)
+                            event_type = event.get("type", "")
+                            if event_type == "content_block_delta":
+                                delta = event.get("delta", {})
+                                if delta.get("type") == "text_delta":
+                                    text = delta.get("text", "")
+                                    if text:
+                                        # Re-emit as OpenAI-compatible SSE for the frontend
+                                        sse_data = {
+                                            "choices": [{"delta": {"content": text}}]
+                                        }
+                                        yield f"data: {json.dumps(sse_data)}\n\n"
+                            elif event_type == "message_stop":
+                                yield "data: [DONE]\n\n"
+                                break
+                        except json.JSONDecodeError:
+                            continue
 
     return StreamingResponse(
         event_stream(),

--- a/src/backend/core/config.py
+++ b/src/backend/core/config.py
@@ -13,12 +13,12 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 
-# MiniMax API
-MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY", "")
+# Claude API (Anthropic)
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
 
-MINIMAX_BASE_URL = "https://api.minimaxi.com/v1"
-MODEL_NAME = "MiniMax-M2.5"
-DEFAULT_MAX_TOKENS = 65536
+ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
+MODEL_NAME = os.getenv("APEX_MODEL", "claude-sonnet-4-6")
+DEFAULT_MAX_TOKENS = 16384
 DEFAULT_TEMPERATURE = 1.0
 
 SWARM_DEFAULTS = {

--- a/src/backend/core/static/index.html
+++ b/src/backend/core/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apex — Agent Swarm</title>
-    <meta name="description" content="Autonomous agent swarm powered by MiniMax-M2.5" />
+    <meta name="description" content="Autonomous agent swarm powered by Claude" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -193,9 +193,9 @@
                 </svg>
               </div>
               <h2>Apex Chat</h2>
-              <p>Direct conversation with <strong>MiniMax-M2.5</strong></p>
+              <p>Direct conversation with <strong>Claude</strong></p>
               <div class="suggestions">
-                <button class="suggestion" data-msg="What makes MiniMax-M2.5 special compared to other AI models?">What makes M2.5 special?</button>
+                <button class="suggestion" data-msg="What makes you unique compared to other AI models?">What makes Claude special?</button>
                 <button class="suggestion" data-msg="Write a Python async web scraper with error handling">Write a Python scraper</button>
                 <button class="suggestion" data-msg="Explain quantum computing in simple terms">Explain quantum computing</button>
               </div>
@@ -211,7 +211,7 @@
               </svg>
             </button>
           </div>
-          <span class="input-hint">MiniMax-M2.5</span>
+          <span class="input-hint">Claude Sonnet 4.6</span>
         </footer>
       </div>
     </div>

--- a/src/backend/core/swarm/llm.py
+++ b/src/backend/core/swarm/llm.py
@@ -1,4 +1,4 @@
-"""LLM client for swarm agents using the MiniMax API."""
+"""LLM client for swarm agents using the Anthropic Claude API."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from typing import AsyncGenerator
 
 import httpx
 
-from ..config import MINIMAX_API_KEY, MINIMAX_BASE_URL, MODEL_NAME
+from ..config import ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, MODEL_NAME
 from .models import AgentRole
 from .roles import ROLE_CONFIGS
 
@@ -17,7 +17,7 @@ logger = logging.getLogger("apex.swarm.llm")
 
 # Simple rate-limit guard: minimum seconds between API calls
 _call_lock = asyncio.Lock()
-_MIN_CALL_GAP = 1.0
+_MIN_CALL_GAP = 0.5
 _last_call_time: float = 0.0
 
 
@@ -32,28 +32,50 @@ async def _rate_limit_wait() -> None:
         _last_call_time = asyncio.get_running_loop().time()
 
 
+def _to_anthropic_messages(messages: list[dict]) -> tuple[str, list[dict]]:
+    """Convert OpenAI-style messages to Anthropic format.
+
+    Returns (system_prompt, messages) where system is extracted
+    and messages only contain user/assistant roles.
+    """
+    system = ""
+    anthropic_msgs = []
+    for msg in messages:
+        if msg["role"] == "system":
+            system = msg["content"]
+        else:
+            anthropic_msgs.append({"role": msg["role"], "content": msg["content"]})
+    return system, anthropic_msgs
+
+
 class LLMClient:
-    """Thin async wrapper around the MiniMax chat-completions endpoint."""
+    """Thin async wrapper around the Anthropic Messages API."""
 
     MAX_RETRIES = 4
     BACKOFF_BASE = 5  # seconds: 5, 10, 20, 40
 
     def __init__(self) -> None:
-        self._url = f"{MINIMAX_BASE_URL}/chat/completions"
+        self._url = f"{ANTHROPIC_BASE_URL}/messages"
         self._headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {MINIMAX_API_KEY}",
+            "x-api-key": ANTHROPIC_API_KEY,
+            "anthropic-version": "2023-06-01",
         }
 
     def _build_payload(self, messages: list[dict], role: AgentRole, *, stream: bool) -> dict:
         cfg = ROLE_CONFIGS[role]
-        return {
+        system, msgs = _to_anthropic_messages(messages)
+        payload: dict = {
             "model": MODEL_NAME,
-            "messages": messages,
-            "stream": stream,
-            "temperature": cfg["temperature"],
+            "messages": msgs,
             "max_tokens": cfg["max_tokens"],
+            "temperature": cfg["temperature"],
         }
+        if system:
+            payload["system"] = system
+        if stream:
+            payload["stream"] = True
+        return payload
 
     async def call(self, messages: list[dict], role: AgentRole) -> str:
         """Send a non-streaming request and return the full response text."""
@@ -67,11 +89,20 @@ class LLMClient:
                     logger.warning("Rate limited (429), retrying in %ds (%d/%d)", wait, attempt + 1, self.MAX_RETRIES)
                     await asyncio.sleep(wait)
                     continue
+                if resp.status_code == 529 and attempt < self.MAX_RETRIES:
+                    wait = self.BACKOFF_BASE * (2 ** attempt)
+                    logger.warning("API overloaded (529), retrying in %ds (%d/%d)", wait, attempt + 1, self.MAX_RETRIES)
+                    await asyncio.sleep(wait)
+                    continue
                 if resp.status_code != 200:
-                    logger.error("MiniMax API error %s: %s", resp.status_code, resp.text)
+                    logger.error("Claude API error %s: %s", resp.status_code, resp.text)
                     return f"[LLM Error {resp.status_code}]"
                 data = resp.json()
-                return data["choices"][0]["message"]["content"]
+                # Extract text from content blocks
+                content_blocks = data.get("content", [])
+                return "".join(
+                    block.get("text", "") for block in content_blocks if block.get("type") == "text"
+                )
         return "[LLM Error: max retries exceeded]"
 
     async def stream(self, messages: list[dict], role: AgentRole) -> AsyncGenerator[str, None]:
@@ -81,46 +112,49 @@ class LLMClient:
         for attempt in range(self.MAX_RETRIES + 1):
             await _rate_limit_wait()
 
-            got_429 = False
+            retry = False
             async with httpx.AsyncClient(timeout=120.0) as client:
                 async with client.stream(
                     "POST", self._url, json=payload, headers=self._headers
                 ) as resp:
-                    if resp.status_code == 429 and attempt < self.MAX_RETRIES:
+                    if resp.status_code in (429, 529) and attempt < self.MAX_RETRIES:
                         await resp.aread()
-                        got_429 = True
+                        retry = True
                     elif resp.status_code != 200:
                         error_body = await resp.aread()
                         logger.error(
-                            "MiniMax API stream error %s: %s",
+                            "Claude API stream error %s: %s",
                             resp.status_code,
                             error_body.decode("utf-8", errors="replace"),
                         )
                         yield f"[LLM Error {resp.status_code}]"
                         return
                     else:
-                        # Success — stream the response
+                        # Stream Anthropic SSE events
                         async for line in resp.aiter_lines():
                             if not line:
                                 continue
                             if line.startswith("data:"):
                                 data_str = line[len("data:"):].strip()
-                                if data_str == "[DONE]":
-                                    break
                                 try:
-                                    chunk = json.loads(data_str)
-                                    delta = chunk["choices"][0].get("delta", {})
-                                    content = delta.get("content", "")
-                                    if content:
-                                        yield content
-                                except (json.JSONDecodeError, KeyError, IndexError):
+                                    event = json.loads(data_str)
+                                    event_type = event.get("type", "")
+                                    if event_type == "content_block_delta":
+                                        delta = event.get("delta", {})
+                                        if delta.get("type") == "text_delta":
+                                            text = delta.get("text", "")
+                                            if text:
+                                                yield text
+                                    elif event_type == "message_stop":
+                                        break
+                                except (json.JSONDecodeError, KeyError):
                                     continue
                         return  # done streaming
 
-            # Retry on 429 (after exiting the context managers)
-            if got_429:
+            # Retry on 429/529 (after exiting the context managers)
+            if retry:
                 wait = self.BACKOFF_BASE * (2 ** attempt)
-                logger.warning("Rate limited (429), retrying in %ds (%d/%d)", wait, attempt + 1, self.MAX_RETRIES)
+                logger.warning("Rate limited/overloaded, retrying in %ds (%d/%d)", wait, attempt + 1, self.MAX_RETRIES)
                 await asyncio.sleep(wait)
 
         # All retries exhausted


### PR DESCRIPTION
## Summary
- Replaces MiniMax-M2.5 API with Anthropic Claude API (Messages API)
- Default model: `claude-sonnet-4-6` (configurable via `APEX_MODEL` env var)
- Uses `x-api-key` auth header and `anthropic-version: 2023-06-01`
- LLM client handles Claude SSE events (`content_block_delta`, `message_stop`)
- Chat proxy re-emits Claude SSE as OpenAI-compatible format for the existing frontend
- Adds 529 (overloaded) retry handling alongside existing 429 retry
- Updates all UI text from "MiniMax-M2.5" to "Claude"

## Environment Variables
- `ANTHROPIC_API_KEY` — your Claude API key (in `.env`)
- `APEX_MODEL` — model to use (default: `claude-sonnet-4-6`)