### PR TITLE
Validate chat endpoint messages before sending to Claude API

### DIFF
--- a/src/backend/core/app.py
+++ b/src/backend/core/app.py
@@ -77,6 +77,9 @@ async def chat(request: Request) -> StreamingResponse:
     body = await request.json()
     messages: list[dict] = body.get("messages", [])
 
+    if not messages:
+        return JSONResponse(status_code=400, content={"error": "messages is required"})
+
     # Extract system message for Anthropic format
     system_prompt = ""
     anthropic_msgs = []
@@ -85,6 +88,9 @@ async def chat(request: Request) -> StreamingResponse:
             system_prompt = msg["content"]
         else:
             anthropic_msgs.append({"role": msg["role"], "content": msg["content"]})
+
+    if not anthropic_msgs:
+        return JSONResponse(status_code=400, content={"error": "at least one user message is required"})
 
     payload: dict = {
         "model": MODEL_NAME,


### PR DESCRIPTION
## Summary
- Returns 400 error if `messages` is empty
- Returns 400 error if only system messages are provided (no user/assistant messages)
- Prevents forwarding invalid requests to Anthropic API

Fixes #49