### PR TITLE
Fix session cleanup race condition with WebSocket clients

### DIFF
--- a/src/backend/core/app.py
+++ b/src/backend/core/app.py
@@ -180,6 +180,8 @@ async def swarm_start(request: Request) -> JSONResponse:
         try:
             await engine.run(query)
         finally:
+            # Give WebSocket clients time to drain final events before cleanup
+            await asyncio.sleep(2)
             swarm_sessions.pop(session.id, None)
             swarm_tasks.pop(session.id, None)
 


### PR DESCRIPTION
## Summary
- Adds 2-second delay in `_run_and_cleanup()` before removing session from `swarm_sessions`
- Ensures WebSocket clients receive final events (report, completion) before session is cleaned up
- Without this fix, the frontend UI could get stuck in "running" state

Fixes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of WebSocket event delivery by ensuring clients receive all final events during engine shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->