### PR TITLE
Close LLM and search HTTP clients on app shutdown

### DIFF
--- a/src/backend/core/app.py
+++ b/src/backend/core/app.py
@@ -32,6 +32,8 @@ from .swarm import (
     SwarmEngine,
     SwarmSession,
 )
+from .swarm.llm import _close_http_client as _close_llm_client
+from .swarm.search import _close_http_client as _close_search_client
 
 logger = logging.getLogger("apex")
 
@@ -65,6 +67,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     if _chat_http_client is not None:
         await _chat_http_client.aclose()
         _chat_http_client = None
+    await _close_llm_client()
+    await _close_search_client()
 
 
 STATIC_DIR = Path(__file__).parent / "static"


### PR DESCRIPTION
Fixes #68

Imports `_close_http_client` from both `swarm.llm` and `swarm.search` and calls them in the `lifespan` shutdown handler, ensuring all shared HTTP clients are properly closed when the app shuts down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend resource cleanup procedures during application shutdown to ensure proper teardown of HTTP clients and related services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->