### PR TITLE
Update README to reference Claude API instead of MiniMax

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -5,7 +5,7 @@ Get up and running in 2 minutes.
 ## Prerequisites
 
 - Python 3.11+
-- A MiniMax API key
+- An Anthropic API key
 
 ## 1. Install
 
@@ -21,10 +21,10 @@ pip install -r requirements.txt
 cp .env.example .env
 ```
 
-Edit `.env` and add your MiniMax API key:
+Edit `.env` and add your Anthropic API key:
 
 ```
-MINIMAX_API_KEY=your-key-here
+ANTHROPIC_API_KEY=your-key-here
 ```
 
 ## 3. Run
@@ -38,7 +38,7 @@ Open **http://localhost:8000** in your browser.
 ## 4. Try It
 
 - **Swarm mode** (default): Enter a research topic and watch agents work in parallel
-- **Chat mode**: Click "Chat" in the header for direct conversation with MiniMax-M2.5
+- **Chat mode**: Click "Chat" in the header for direct conversation with Claude
 
 ## Optional: Docker
 
@@ -51,7 +51,7 @@ docker run -p 8000:8000 --env-file .env apex
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MINIMAX_API_KEY` | (required) | MiniMax API key |
+| `ANTHROPIC_API_KEY` | (required) | Anthropic API key |
 | `FIRECRAWL_BASE_URL` | `https://api-production-91c7.up.railway.app` | Web search API |
 | `APEX_HOST` | `0.0.0.0` | Bind address |
 | `APEX_PORT` | `8000` | Port |
@@ -60,12 +60,12 @@ docker run -p 8000:8000 --env-file .env apex
 ## Troubleshooting
 
 ### App won't start?
-- Check that `MINIMAX_API_KEY` is set in `.env`
+- Check that `ANTHROPIC_API_KEY` is set in `.env`
 - Ensure Python 3.11+ is installed: `python --version`
 
 ### Swarm produces errors?
 - Check the terminal for log output
-- Verify your MiniMax API key is valid
+- Verify your Anthropic API key is valid
 - The Firecrawl search API must be reachable
 
 ## Next Steps

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p><strong>Autonomous Agent Swarm for Deep Research</strong></p>
 
 <p>
-A multi-agent research pipeline powered by MiniMax-M2.5 with real-time visualization.<br/>
+A multi-agent research pipeline powered by Claude with real-time visualization.<br/>
 Agents plan, research, analyze, fact-check, and write comprehensive reports autonomously.
 </p>
 
@@ -19,7 +19,7 @@ Agents plan, research, analyze, fact-check, and write comprehensive reports auto
 - **Live Web Research** — Agents search the web via Firecrawl API, with reflection cycles to fill gaps
 - **Real-Time Dashboard** — WebSocket-powered UI shows agent activity, streaming output, and progress
 - **Rich Report Generation** — Multi-stage report engine with templates, structured IR, and HTML rendering
-- **Direct Chat** — Also supports direct conversation with MiniMax-M2.5
+- **Direct Chat** — Also supports direct conversation with Claude
 
 ## Architecture
 
@@ -35,8 +35,8 @@ Browser (HTML/JS/CSS)
          │              │              │
     SwarmEngine    LLMClient    WebSearchClient
          │              │              │
-    Multi-agent    MiniMax API    Firecrawl API
-    pipeline       (M2.5)        (web search)
+    Multi-agent    Claude API     Firecrawl API
+    pipeline       (Anthropic)   (web search)
 ```
 
 ## Quick Start
@@ -44,7 +44,7 @@ Browser (HTML/JS/CSS)
 ### Prerequisites
 
 - Python 3.11+
-- A [MiniMax API key](https://www.minimaxi.com/)
+- An [Anthropic API key](https://console.anthropic.com/)
 
 ### Setup
 
@@ -58,7 +58,7 @@ pip install -r requirements.txt
 
 # Configure your API key
 cp .env.example .env
-# Edit .env and add your MINIMAX_API_KEY
+# Edit .env and add your ANTHROPIC_API_KEY
 ```
 
 ### Run
@@ -73,7 +73,7 @@ The app starts at **http://localhost:8000**.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MINIMAX_API_KEY` | (required) | Your MiniMax API key |
+| `ANTHROPIC_API_KEY` | (required) | Your Anthropic API key |
 | `FIRECRAWL_BASE_URL` | `https://api-production-91c7.up.railway.app` | Firecrawl search API URL |
 | `APEX_HOST` | `0.0.0.0` | Server bind address |
 | `APEX_PORT` | `8000` | Server port |
@@ -109,7 +109,7 @@ src/backend/core/
 │   └── style.css
 └── swarm/
     ├── engine.py        # Swarm pipeline orchestrator
-    ├── llm.py           # MiniMax API client
+    ├── llm.py           # Claude API client
     ├── search.py        # Firecrawl web search client
     ├── models.py        # Data models
     ├── events.py        # WebSocket event emitter


### PR DESCRIPTION
## Summary
- Replace all MiniMax-M2.5 references with Claude/Anthropic in README.md and QUICKSTART.md
- Update API key references, prerequisites, and architecture diagram

Fixes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive updates to quickstart and readme documentation files
  * Revised installation prerequisites and setup instructions
  * Updated environment variable naming conventions and requirements
  * Updated architecture diagrams, descriptions, and code structure documentation
  * Adjusted configuration examples and workflow guidance throughout all documentation sections
  * Enhanced setup clarity for users following installation procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->